### PR TITLE
修复 TABComponentManager 另外2处由于 superView 导致的循环引用

### DIFF
--- a/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Manager/TABComponentManager.m
+++ b/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Manager/TABComponentManager.m
@@ -219,6 +219,7 @@ static NSString * const kTagDefaultFontName = @"HiraKakuProN-W3";
             superView:(UIView *)superView {
     if (@available(iOS 13.0, *)) {
         self.sentryView = TABSentryView.new;
+        // avoid retain cycle
         __weak typeof(self) weakSelf = self;
         __weak typeof(superView) weakSuperView = superView;
         self.sentryView.traitCollectionDidChangeBack = ^{
@@ -375,19 +376,23 @@ static NSString * const kTagDefaultFontName = @"HiraKakuProN-W3";
             return;
         }
         
+        // avoid retain cycle
+        __weak typeof(superView) weakSuperView = superView;
         self.animatedBackgroundColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
+            __strong typeof(weakSuperView) strongSuperView = weakSuperView;
             if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-                return superView.tabAnimated.darkAnimatedBackgroundColor;
+                return strongSuperView.tabAnimated.darkAnimatedBackgroundColor;
             }else {
-                return superView.tabAnimated.animatedBackgroundColor;
+                return strongSuperView.tabAnimated.animatedBackgroundColor;
             }
         }];
 
         self.animatedColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
+            __strong typeof(weakSuperView) strongSuperView = weakSuperView;
             if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-                return superView.tabAnimated.darkAnimatedColor;
+                return strongSuperView.tabAnimated.darkAnimatedColor;
             }else {
-                return superView.tabAnimated.animatedColor;
+                return strongSuperView.tabAnimated.animatedColor;
             }
         }];
         

--- a/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Manager/TableDeDaSelfModel.m
+++ b/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Manager/TableDeDaSelfModel.m
@@ -251,7 +251,7 @@
             __weak typeof(cell) weakCell = cell;
             dispatch_async(dispatch_get_main_queue(), ^{
                 weakCell.tabComponentManager.tabLayer.frame = weakCell.bounds;
-                [TABManagerMethod resetData:cell];
+                [TABManagerMethod resetData:weakCell];
             });
         }
         

--- a/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Model/TABTableAnimated.m
+++ b/AnimatedDemo/AnimatedDemo/TABAnimated/Core/Model/TABTableAnimated.m
@@ -720,7 +720,7 @@
             __weak typeof(cell) weakCell = cell;
             dispatch_async(dispatch_get_main_queue(), ^{
                 weakCell.tabComponentManager.tabLayer.frame = weakCell.bounds;
-                [TABManagerMethod resetData:cell];
+                [TABManagerMethod resetData:weakCell];
             });
         }
         


### PR DESCRIPTION
当**切换深色模式**或者**调整骨架屏容器`View`的布局**时，会触发 `traitCollectionDidChange`方法，进而触发 `TABSentryView`的`traitCollectionDidChangeBack` 回调，最终命中循环引用的代码：
```objc
- (void)tab_traitCollectionDidChange:(UIView *)superView {
    
    if (@available(iOS 13.0, *)) {
        
        if (!superView) {
            return;
        }
        
        self.animatedBackgroundColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
            if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
                return superView.tabAnimated.darkAnimatedBackgroundColor;
            }else {
                return superView.tabAnimated.animatedBackgroundColor;
            }
        }];

        self.animatedColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
            if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
                return superView.tabAnimated.darkAnimatedColor;
            }else {
                return superView.tabAnimated.animatedColor;
            }
        }];

        ...
}
```

`UIColor colorWithDynamicProvider` 的 `block` 会捕获 `superView` 导致循环引用

[FBRetainCycleDetector](https://github.com/facebook/FBRetainCycleDetector) 捕捉到的信息如下：

```
Retain Cycle: (
    "-> UICollectionView ",
    "-> _cellReuseQueues -> __NSDictionaryM ",
    "-> __NSArrayM ",
    "-> WETinyBookTypeListCell ",
    "-> __associated_object -> TABComponentManager ",
    "-> _animatedColor -> UIDynamicProviderColor ",
    "-> _provider -> __NSMallocBlock__ "
)
```
![image](https://user-images.githubusercontent.com/11780294/66458231-cad4f180-eaa4-11e9-9e31-39f10457f6e0.png)
