### PR TITLE
update for iOS 14

### DIFF
--- a/TABAnimatedDemo/TABAnimated/Product/TABAnimatedProductImpl.m
+++ b/TABAnimatedDemo/TABAnimated/Product/TABAnimatedProductImpl.m
@@ -372,14 +372,36 @@
         UIView *subV = subViews[i];
         if (subV.tabAnimated) continue;
         
+        // iOS 14 上的 TableViewCell subviews [_UISystemBackgroundView, X, ... , UITableViewCellContentView]
+        // 排除 iOS 14 上的 _UISystemBackgroundView
+        // !!!: 此处不确定上架 App Store 是否会受影响
+        if (@available(iOS 14, *)) {
+            NSLog(@"%@", NSStringFromClass(subV.class));
+            if (([subV.superview isKindOfClass:[UITableViewCell class]] ||
+                 [subV.superview isKindOfClass:[UICollectionViewCell class]] ||
+                 [subV.superview isKindOfClass:[UITableViewHeaderFooterView class]]) &&
+                 [NSStringFromClass(subV.class) isEqualToString:@"_UISystemBackgroundView"]) {
+                // 此处排除cell中的_UISystemBackgroundView, _UISystemBackgroundView 的 subviews 不为空
+                if (i == 0) {
+                    continue;
+                }
+            }
+        }
+
         [self _recurseProductLayerWithView:subV array:array isCard:isCard];
-        
+
         if ([subV.superview isKindOfClass:[UITableViewCell class]] ||
             [subV.superview isKindOfClass:[UICollectionViewCell class]] ||
             [subV.superview isKindOfClass:[UITableViewHeaderFooterView class]]) {
             // 此处排除cell中的contentView，不生成动画对象
-            if (i == 0) {
-                continue;
+            if (@available(iOS 14, *)) {
+                if (i == (subViews.count - 1)) {
+                    continue;
+                }
+            } else {
+                if (i == 0) {
+                    continue;
+                }
             }
         }
         


### PR DESCRIPTION
**iOS 14 UITableViewCell 的 subviews 有了较大变化**

- iOS 13 中 TableViewCell 的 subviews

> [UITableViewContentView, 自己添加的其他控件]

- iOS 14 中 TableViewCell 的 subviews

> [_UISystemBackgroundView, 自己添加的其他控件, UITableViewContentView]

结果是在 iOS 14 上会跳过 _UISystemBackgroundView, 但是把 UITableViewContentView 也画出骨架来.

因为 iOS 14 还未正式发布, 这里目前基于 beta 3 做了简单的 workaround. **直接判断如果是 `_UISystemBackgroundView` 这个类就直接跳过, 不确定是否影响上架, 需要后续跟进**