### PR TITLE
Update TABAnimatedProductHelper.m

### DIFF
--- a/TABAnimatedDemo/TABAnimated/Product/TABAnimatedProductHelper.m
+++ b/TABAnimatedDemo/TABAnimated/Product/TABAnimatedProductHelper.m
@@ -34,6 +34,9 @@ static const CGFloat kTagLabelMinWidth = 15.f;
     for (int i = 0; i < numIvars; i++) {
         Ivar thisIvar = ivars[i];
         const char *type = ivar_getTypeEncoding(thisIvar);
+        if (type == NULL) {
+            continue;
+        }
         NSString *stringType =  [NSString stringWithCString:type encoding:NSUTF8StringEncoding];
         if (![stringType hasPrefix:@"@"]) {
             continue;


### PR DESCRIPTION
fix:
1. 修复在 cell 属性中，使用到 Swift 中特有的一些属性（如@Published 等）导致crash的问题。